### PR TITLE
Apply useful CSS one-liners that fit current site usage

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -103,6 +103,7 @@ img {
 body {
     background-color: #f7f7f7;
     color: #222;
+    line-height: 1.5;
     font-family:
         -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial,
         sans-serif;
@@ -116,6 +117,7 @@ h4,
 h5,
 h6 {
     font-family: "Helvetica Neue", "Verdana", sans-serif;
+    text-wrap: balance;
 }
 
 nav {
@@ -433,6 +435,10 @@ article {
     word-wrap: break-word;
 }
 
+article p {
+    max-width: 65ch;
+}
+
 article header h1,
 article header h2 {
     word-wrap: break-word;
@@ -518,6 +524,7 @@ pre.line-numbers {
     pre {
         background-color: #141414;
     }
+
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `line-height: 1.5` on `body` for improved baseline readability
- add `text-wrap: balance` for headings to avoid awkward wraps
- add `article p { max-width: 65ch; }` to keep paragraph measure readable
- intentionally skip table/form/motion one-liners that are not currently used by the main generated site

## Verification
- rbenv exec bundle exec bake lint
- rbenv exec bundle exec bake test
- rbenv exec bundle exec bake debug

Closes #31
